### PR TITLE
fix: Dedupe redundant error props in Exec

### DIFF
--- a/src/Console.php
+++ b/src/Console.php
@@ -62,7 +62,7 @@ class Console
         $exec = ($this->shell)($argv);
 
         // errors?
-        if ($exec->error === null) {
+        if (!$exec->error) {
             $command = $this->newCommand((string) $exec->class);
             $method = $exec->method;
             $options = $exec->options;
@@ -70,8 +70,8 @@ class Console
             return $command->$method($options, ...$arguments);
         }
 
-        fwrite($this->stderr, $exec->exception->getMessage() . PHP_EOL);
-        $code = (int) $exec->exception->getCode();
+        fwrite($this->stderr, $exec->error->getMessage() . PHP_EOL);
+        $code = (int) $exec->error->getCode();
 
         if (! $code) {
             $code = 1;

--- a/src/Exec.php
+++ b/src/Exec.php
@@ -15,8 +15,7 @@ class Exec
         public readonly ?string $method = null,
         public readonly ?Options $options = new Options(),
         public readonly array $arguments = [],
-        public readonly ?string $error = null,
-        public readonly ?Throwable $exception = null,
+        public readonly ?Throwable $error = null,
     ) {
     }
 }

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -87,7 +87,6 @@ class Shell
         $class = null;
         $options = null;
         $arguments = [];
-        $error = null;
         $exception = null;
 
         try {
@@ -97,7 +96,6 @@ class Shell
             $rm = $this->reflector->getMethod($rc, $this->config->method);
             $arguments = $this->getArguments($rm, $argv);
         } catch (Throwable $e) {
-            $error = get_class($e);
             $exception = $e;
         }
 
@@ -106,8 +104,7 @@ class Shell
             method: $this->config->method,
             options: $options,
             arguments: $arguments,
-            error: $error,
-            exception: $exception,
+            error: $exception,
         );
     }
 

--- a/tests/ShellTest.php
+++ b/tests/ShellTest.php
@@ -21,7 +21,6 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(Options::CLASS, $exec->options);
         $this->assertSame([1, 'a', 'b', 'c'], $exec->arguments);
         $this->assertNull($exec->error);
-        $this->assertNull($exec->exception);
     }
 
     public function testMissingArgument()
@@ -30,8 +29,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $exec = ($this->shell)($argv);
         $this->assertSame(Fake\Command\FooBar\Baz::CLASS, $exec->class);
         $this->assertSame('__invoke', $exec->method);
-        $this->assertSame(Exception\ArgumentRequired::CLASS, $exec->error);
-        $this->assertInstanceof(Exception\ArgumentRequired::CLASS, $exec->exception);
+        $this->assertInstanceof(Exception\ArgumentRequired::CLASS, $exec->error);
     }
 
     public function testClassNotFound()
@@ -40,8 +38,7 @@ class ShellTest extends \PHPUnit\Framework\TestCase
         $exec = ($this->shell)($argv);
         $this->assertNull($exec->class);
         $this->assertSame('__invoke', $exec->method);
-        $this->assertSame(Exception\ClassNotFound::CLASS, $exec->error);
-        $this->assertInstanceof(Exception\ClassNotFound::CLASS, $exec->exception);
+        $this->assertInstanceof(Exception\ClassNotFound::CLASS, $exec->error);
     }
 
     public function testHelp()


### PR DESCRIPTION
Resolves the following lint error:

```
 ------ ---------------------------------------------------- 
  Line   Console.php                                         
 ------ ---------------------------------------------------- 
  :73    Cannot call method getMessage() on Throwable|null.  
  :74    Cannot call method getCode() on Throwable|null.     
 ------ ---------------------------------------------------- 
```