### PR TITLE
fix: Replace ClassNotFound constructor with factory

### DIFF
--- a/src/Exception/ClassNotFound.php
+++ b/src/Exception/ClassNotFound.php
@@ -7,13 +7,13 @@ use AutoShell\Exception;
 
 class ClassNotFound extends Exception
 {
-    public function __construct(
+    public static function new(
         string $commandName,
         string $class
-    ) {
+    ): self {
         $message = "The command '{$commandName}' maps to the class "
             . "'{$class}', which does not exist.";
 
-        return parent::__construct($message);
+        return new self($message);
     }
 }

--- a/src/Shell.php
+++ b/src/Shell.php
@@ -131,7 +131,7 @@ class Shell
         $class .= $this->config->suffix;
 
         if (! class_exists($class)) {
-            throw new Exception\ClassNotFound($commandName, $class);
+            throw Exception\ClassNotFound::new($commandName, $class);
         }
 
         return $class;


### PR DESCRIPTION
Fixes the following lint error:

```
 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  Line   Exception/ClassNotFound.php                                                                                                 
 ------ ---------------------------------------------------------------------------------------------------------------------------- 
  :17    Method AutoShell\Exception\ClassNotFound::__construct() with return type void returns void but should not return anything.  
  :17    Result of method Exception::__construct() (void) is used.                                                                   
 ------ ---------------------------------------------------------------------------------------------------------------------------- 
```