### PR TITLE
fix: Fix lint error in Format::markup()

### DIFF
--- a/src/Format.php
+++ b/src/Format.php
@@ -49,7 +49,7 @@ class Format
         ];
 
         foreach ($markup as $find => $replace) {
-            $str = preg_replace($find, $replace, $str);
+            $str = preg_replace($find, $replace, $str) ?? '';
         }
 
         return strtr($str, ['\\' => '']) . static::RESET;


### PR DESCRIPTION
Fixes the following lint error:

```
 ------ ----------------------------------------------------------------------------------------- 
  Line   Format.php                                                                               
 ------ ----------------------------------------------------------------------------------------- 
  :52    Parameter #3 $subject of function preg_replace expects array|string, string|null given.  
  :55    Parameter #1 $str of function strtr expects string, string|null given.                   
 ------ ----------------------------------------------------------------------------------------- 
```